### PR TITLE
RateLimiter use the user email address

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - 'documentation/**'
 
 env:
-  MAJOR_MINOR_PATCH: 0.8.0
+  MAJOR_MINOR_PATCH: 0.7.0
   GIN_MODE: release
   MAIN_PACKAGE: 'cmd/document-design-gateway/main.go'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - 'documentation/**'
 
 env:
-  MAJOR_MINOR_PATCH: 0.6.1
+  MAJOR_MINOR_PATCH: 0.7.1
   GIN_MODE: release
   MAIN_PACKAGE: 'cmd/document-design-gateway/main.go'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - 'documentation/**'
 
 env:
-  MAJOR_MINOR_PATCH: 0.7.1
+  MAJOR_MINOR_PATCH: 0.8.0
   GIN_MODE: release
   MAIN_PACKAGE: 'cmd/document-design-gateway/main.go'
 

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ Tests need to be maintained as normal code. Keep that in mind while you write te
 # Rate limit for access for demonstration
 As it is planned to provide a public demonstration, a github account is needed to access the endpoints. Each github account can generate up to three document every hour.
 
-The application needs access to your github user id because of that.
+The application needs access to your github user email to identify you.

--- a/internal/app/document/preview_service.go
+++ b/internal/app/document/preview_service.go
@@ -20,6 +20,8 @@ import (
 	"github.com/kinneko-de/restaurant-document-design-gateway/internal/httpheader"
 	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	github "github.com/kinneko-de/restaurant-document-design-gateway/internal/app/github/oauth"
 )
 
 var (
@@ -46,13 +48,15 @@ func GeneratePreviewDemo(ctx *gin.Context) {
 }
 
 func tryToGeneratePreview(ctx *gin.Context) {
-	userId := ctx.Keys["userId"]
-	if userId == nil {
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "user id is not set"})
+	UserContextKeyValue := ctx.Keys[github.UserContextKey]
+	if UserContextKeyValue == nil {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "user email is not set"})
 		return
 	}
-	if requestIsLimited(userId.(string)) {
-		ctx.JSON(http.StatusTooManyRequests, gin.H{"error": "rate limit exceeded. try again later"})
+	userEmail := UserContextKeyValue.(string)
+
+	if requestIsLimited(userEmail) {
+		ctx.JSON(http.StatusTooManyRequests, gin.H{"error": fmt.Sprintf("rate limit for %s exceeded. try again later", userEmail)})
 		return
 	}
 


### PR DESCRIPTION
- github oauth request is reduced to scope for email
- email is stored in context
- email is used as identifier for rate limiter